### PR TITLE
Fix spy disguise outline animation covering the screen

### DIFF
--- a/scripts/hudanimations_7hud.txt
+++ b/scripts/hudanimations_7hud.txt
@@ -254,3 +254,36 @@ event HudMedicChargedStop
 	Animate	ChargeMeter 	        FgColor		"BuildingUber"		Linear 0.0 0.0001
     Animate	ChargeMeter 	        BgColor		"HudBG"		        linear 0.0 0.0
 }
+
+//===========================================
+
+// Spy Disguise
+event HudSpyDisguiseChanged
+{
+	Animate PlayerStatusSpyOutlineImage		Alpha		"255"			Linear 0.0 0.2
+	
+	Animate PlayerStatusSpyOutlineImage		Position	"c-200 c-200"	        Linear 0.0 0.2
+	Animate PlayerStatusSpyOutlineImage		Size		"400 400"		Linear 0.0 0.2
+
+	RunEvent HudSpyDisguiseHide	0.7
+}
+
+event HudSpyDisguiseHide
+{
+	Animate PlayerStatusSpyOutlineImage		Position	"3 413"			Linear 0.0 0.2
+	Animate PlayerStatusSpyOutlineImage		Size		"55 55"			Linear 0.0 0.2
+	
+	Animate PlayerStatusSpyOutlineImage		Alpha		"0"			Linear 0.2 0.1
+}
+
+event HudSpyDisguiseFadeIn
+{
+	Animate PlayerStatusSpyImage			Alpha		"255"			Linear 0.9 0.1
+	Animate PlayerStatusClassImage			Alpha		"255"			Linear 0.0 0.0	
+}
+
+event HudSpyDisguiseFadeOut
+{
+	Animate PlayerStatusSpyImage			Alpha		"1"			Linear 0.9 0.1	
+	Animate PlayerStatusClassImage			Alpha		"1"			Linear 0.0 0.0
+}


### PR DESCRIPTION
Looks like it was forgotten when the custom animations were moved to a new file.