### PR TITLE
Fix lingering animation on death

### DIFF
--- a/scripts/hudanimations_7hud.txt
+++ b/scripts/hudanimations_7hud.txt
@@ -336,3 +336,14 @@ event WinPanel_NormalPos
 {
 	Animate WinPanel ypos r132 Linear 0 0
 }
+
+//===========================================
+
+// lingering animation on death fix
+event HudSnapShotReminderIn 
+{
+    RunEvent HudHealthDyingPulseStop 0.0
+    RunEvent HudHealthBonusPulseStop 0.0
+    RunEvent HudLowAmmoPulseStop 0.0
+    RunEvent HudMedicChargedStop 0.0
+}


### PR DESCRIPTION
This resets the ammo, uber and health animations on freezecam to fix a bug where if you die with any of these animations on, they will linger after death on your respawn.