### PR TITLE
Fix emptiness in freezeframe on class selections

### DIFF
--- a/resource/ui/classselection.res
+++ b/resource/ui/classselection.res
@@ -1406,6 +1406,7 @@
 		"visible"		"1"
 		"enabled"		"1"
 		
+		"render_texture"    "0"
 		"fov"			"25"
 		"allow_rot"		"0"
 

--- a/scripts/hudanimations_7hud.txt
+++ b/scripts/hudanimations_7hud.txt
@@ -340,7 +340,7 @@ event WinPanel_NormalPos
 //===========================================
 
 // lingering animation on death fix
-event HudSnapShotReminderIn 
+event HudSnapShotReminderIn
 {
     RunEvent HudHealthDyingPulseStop 0.0
     RunEvent HudHealthBonusPulseStop 0.0


### PR DESCRIPTION
This removes the black background in the class selection menu when the client view freezes, for example during freezecams.

It also removes an extra space I accidentally included in my previous PR.