### PR TITLE
halloween 2024 ui scaling band aid fix

### DIFF
--- a/resource/clientscheme.res
+++ b/resource/clientscheme.res
@@ -974,7 +974,7 @@ Scheme
 			{
 				"name"		"Neutra Display Titling"		[!$OSX]
 				"name"		"DOCK11 Heavy"					[$OSX]
-				"tall"		"56"
+				"tall"		"42"
 				"additive"		"0"
 				"antialias"	"1"
 			}
@@ -3793,10 +3793,20 @@ Scheme
 			"1"
 			{
 				"name"		"AvenirLTStd-Book"
-				"tall"		"22"
+                "tall"		"24"
+                "weight"    "500"
+                "yres"      "1 1199"
 				"additive"	"0"
-				"antialias" "1"
+				"antialias"	"1"
 			}
+			"2" // Misyl: Proportional
+            {
+                "name"      "AvenirLTStd-Book"
+                "tall"      "10"
+                "weight"    "500"
+                "additive"  "0"
+                "antialias" "1"
+            }
 		}
 		"HudFontMediumBold"
 		{

--- a/resource/clientscheme.res
+++ b/resource/clientscheme.res
@@ -974,7 +974,7 @@ Scheme
 			{
 				"name"		"Neutra Display Titling"		[!$OSX]
 				"name"		"DOCK11 Heavy"					[$OSX]
-				"tall"		"42"
+				"tall"		"56"
 				"additive"		"0"
 				"antialias"	"1"
 			}


### PR DESCRIPTION
some of the menus like the gear icon casual competitive menu top left on main menu got noticeably gigantic this fixes it by copying HudFontMediumSecondary from updated default hud except the font